### PR TITLE
Fix comment in analysis notebook

### DIFF
--- a/e_commerce_analysis.ipynb
+++ b/e_commerce_analysis.ipynb
@@ -182,7 +182,7 @@
         "customer_sales = sales_df.groupby('Order ID').agg({\n",
         "    'Item Total': ['sum', 'mean'],\n",
         "    'Order Date': 'max',\n",
-        "    'Order ID': 'count'  # Assuming each order has a unique order_id\n",
+        "    'Order ID': 'count'  # Assuming each order has a unique Order ID\n",
         "}).reset_index()\n",
         "\n",
         "# Flatten the MultiIndex columns\n",


### PR DESCRIPTION
## Summary
- adjust comment in sales aggregation step of the notebook to match `Order ID` column name

## Testing
- `grep -n "unique Order ID" -n e_commerce_analysis.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_6841e90962988331944c635a7b3ec008